### PR TITLE
Add simple dashboard page

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>스쿨플랜 AI - 대시보드</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            font-family: 'Noto Sans KR', sans-serif;
+        }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-800">
+    <header class="bg-white shadow-md w-full">
+        <div class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <div>
+                <h1 class="text-2xl font-bold text-[#7A9D54]">📝 스쿨플랜 AI</h1>
+                <p class="text-sm text-gray-500">대시보드</p>
+            </div>
+            <nav>
+                <a href="index.html" class="text-sm text-[#7A9D54] hover:underline">운영계획서 생성기</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container mx-auto p-6">
+        <section class="mb-6">
+            <h2 class="text-xl font-bold mb-4 border-b pb-2">요약 정보</h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <div class="bg-white p-4 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">생성한 계획서 수</p>
+                    <p class="text-2xl font-semibold mt-2">0</p>
+                </div>
+                <div class="bg-white p-4 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">최근 사용</p>
+                    <p class="text-2xl font-semibold mt-2">-</p>
+                </div>
+                <div class="bg-white p-4 rounded-lg shadow">
+                    <p class="text-sm text-gray-500">업데이트 예정</p>
+                    <p class="text-2xl font-semibold mt-2">Soon</p>
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="text-xl font-bold mb-4 border-b pb-2">최근 활동</h2>
+            <p class="text-gray-500">곧 이곳에서 활동 내역을 확인할 수 있습니다.</p>
+        </section>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -81,9 +81,14 @@
 
     <div id="app" class="flex flex-col min-h-screen">
         <header class="bg-white shadow-md w-full">
-            <div class="container mx-auto px-6 py-4">
-                <h1 class="text-2xl font-bold text-[#7A9D54]">📝 스쿨플랜 AI</h1>
-                <p class="text-sm text-gray-500">학교 운영계획서 초안 생성기</p>
+            <div class="container mx-auto px-6 py-4 flex justify-between items-center">
+                <div>
+                    <h1 class="text-2xl font-bold text-[#7A9D54]">📝 스쿨플랜 AI</h1>
+                    <p class="text-sm text-gray-500">학교 운영계획서 초안 생성기</p>
+                </div>
+                <nav>
+                    <a href="dashboard.html" class="text-sm text-[#7A9D54] hover:underline">대시보드</a>
+                </nav>
             </div>
         </header>
 


### PR DESCRIPTION
## Summary
- add a new `dashboard.html` page as a placeholder dashboard
- link to the dashboard from the main `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f5d97099483249dbca59850bab7d9